### PR TITLE
translate contributing/code-of-conduct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,22 @@
 node_modules
 *.png
+
+### Intellij ###
+.idea/
+
+### SublimeText ###
+# Cache files for Sublime Text
+*.tmlanguage.cache
+*.tmPreferences.cache
+*.stTheme.cache
+
+# Workspace files are user-specific
+*.sublime-workspace
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace

--- a/docs/contributing/code-of-conduct.md
+++ b/docs/contributing/code-of-conduct.md
@@ -1,76 +1,80 @@
 ---
-title: Gatsby Contributor Covenant Code of Conduct
+title: Charte Code de Conduite Contributeurs
 ---
 
-## Our Pledge
+## Notre engagement
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of
-experience, nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+Dans l'intérêt de favoriser un environnement ouvert et accueillant, nous nous
+engageons, en tant que responsables et en tant que personnes contribuant à ce
+projet, à faire de la participation une expérience exempte de harcèlement pour
+tout le monde, quel que soit le niveau d'expérience, le sexe, l'identité ou
+l'expression de genre, l'orientation sexuelle, le handicap, l'apparence
+personnelle, la taille physique, l'origine ethnique, l'âge, la religion ou la
+nationalité.
 
-## Our Standards
+## Nos critères
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Exemples de comportements qui contribuent à créer un environnement positif :
 
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
+- l'utilisation d'un langage ouvert et accueillant
+- le respect des différents points de vue et expériences vécues
+- accepter poliment les critiques constructives
+- se concentrer sur ce qui est meilleur pour la communauté
+- faire preuve d'empathie envers les autres membres de la communauté
 
-Examples of unacceptable behavior by participants include:
+Exemples de comportements non acceptables :
 
-- The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-- Trolling, insulting/derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-- Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+- l'utilisation de langage ou d'imagerie sexualisés et les avances sexuelles non
+  sollicitées
+- le _trolling_, les commentaires insultants ou désobligeants, et les attaques
+  personnelles ou d'ordre politique
+- le harcèlement en public ou en privé
+- la publication d'informations privées de tierces personnes, telles que des
+  adresses physiques ou électroniques, sans permission explicite
+- toute conduite qui pourrait être raisonnablement considérée comme inappropriée
+  dans le milieu professionnel
 
-## Our Responsibilities
+## Nos responsabilités
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Les responsables du projet doivent clarifier les critères de comportement
+acceptables de ce projet : il est attendu que ces personnes prennent les
+mesures correctives justes comme réponse à tout comportement inacceptable.
 
-Project maintainers have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned with this code of conduct, or to ban temporarily or permanently any
-contributor for other behaviors that they deem inappropriate, threatening,
-offensive, or harmful.
+Les personnes qui assurent la maintenance du projet ont le droit et la
+responsabilité de supprimer, modifier ou rejeter les commentaires, _commits_,
+code, modifications du wiki, questions et autres contributions qui ne respectent
+pas ce Code de Conduite, ou de bannir temporairement ou définitivement
+quiconque, suite à des comportements jugés inappropriés, menaçants, injurieux,
+ou nuisibles.
 
-## Scope
+## Objectifs
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+Ce Code de Conduite s'applique à la fois au sein des espaces du projet ainsi que
+dans les espaces publics lorsqu'un individu représente le projet ou sa
+communauté. Font parties des exemples de représentation d'un projet ou d'une
+communauté le fait d'utiliser une adresse email propre au projet, de poster sur
+les réseaux sociaux avec un compte officiel, ou d'intervenir pour représenter le
+projet au cours d'un événement en-ligne ou hors-ligne. La représentation du
+projet pourra être autrement définie et clarifiée par les responsables du
+projet.
 
-## Enforcement
+## Application
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at
-[conduct@gatsbyjs.com](mailto:conduct@gatsbyjs.com). All complaints will be
-reviewed and investigated and will result in a response that is deemed necessary
-and appropriate to the circumstances. The project team is obligated to maintain
-confidentiality with regard to the reporter of an incident. Further details of
-specific enforcement policies may be posted separately.
+Les cas de comportements abusifs, harcelants ou tout autre comportement
+inacceptable peuvent être signalés en contactant l'équipe du projet à
+[conduct@gatsbyjs.com](mailto:conduct@gatsbyjs.com). Toutes les plaintes seront examinées et étudiées
+et se traduiront par une réponse appropriée aux
+circonstances. L'équipe du projet s'engage à garder confidentielles les
+informations de la personne qui remonte un incident. Plus de détails sur
+la politique de mise en application des règles peuvent être publiés séparément.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+Les membres du projet qui ne suivent ou qui n'appliquent pas le Code de
+Conduite de bonne foi s'exposent temporairement ou de façon permanente à des
+répercussions définies par d'autres membres de la direction du projet.
 
 ## Attribution
 
-This Code of Conduct is adapted from the Contributor Covenant, version 1.4.
+Ce Code de Conduite est adapté du Contributor Covenant, version 1.4.
 
 - homepage: https://contributor-covenant.org
-- version: https://contributor-covenant.org/version/1/4/
+- version: https://www.contributor-covenant.org/fr/version/1/4/code-of-conduct


### PR DESCRIPTION
Translated using the available french version on contributor-covenant.org. I did a translation by myself before realizing at the end of the file that this website might already have a french version available... 😅