### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Quelques liens utiles :
 * [Style Guide](/style-guide.md)
 * [Gatsby Translation Guide](https://www.gatsbyjs.org/contributing/gatsby-docs-translation-guide/) : idéalement à lire avant de vous lancer dans l'aventure. 
 * [Liste des termes communs](/common-terms.md) : liste évolutive des termes qui peuvent poser un problème de traduction. 
-* [Gatsby Discord](https://gatsby.dev/discord) : rejoignez-nous pour discuter librement dans le salon dédié : `localization-fr`. 
+* [Gatsby Discord](https://gatsby.dev/discord) : rejoignez-nous pour discuter librement dans le salon dédié : `translation-fr`. 
 
 ## Comment traduire une page ? 
 


### PR DESCRIPTION
Gatsby Discord channels are now `translation-<country>`, not `localization-<country>`.